### PR TITLE
fix game running initially in editor

### DIFF
--- a/src/systems/RouterSystem.ts
+++ b/src/systems/RouterSystem.ts
@@ -56,6 +56,9 @@ export function createRouterSystem<Routes extends IRouteRecord>(
     #previousRoute: string | undefined;
     #input: ReturnType<typeof GlobalInputEntity.create> | undefined;
     start(state: Context) {
+      const route = parseRouteFromLocation();
+      state.currentRoute = route ?? (defaultRoute as string);
+
       if (this.#input === undefined) {
         this.#input = GlobalInputEntity.create(state);
       }


### PR DESCRIPTION
There was some lag between when the router system started the routes for the current route, and when the current route would be determined from the current Location. This changes it such that the current route is determined immediately, before the current route's systems are started.