### PR TITLE
improve entity meta data

### DIFF
--- a/src/Component.test.ts
+++ b/src/Component.test.ts
@@ -3,8 +3,7 @@ import assert from "node:assert";
 import { IComponentDefinition, defineComponent } from "./Component";
 import { Sprite, Vector3 } from "three";
 import { WithGetterSetter } from "./Mixins";
-
-class BaseEntity {}
+import { World } from "./EntityManager";
 
 interface ISpriteComponent {
   sprite: Sprite;
@@ -65,7 +64,8 @@ const VelocityComponent: IComponentDefinition<
 );
 
 test("compose entities from components", () => {
-  const entity = new BaseEntity();
+  const world = new World();
+  const entity = world.addEntity();
   SpriteComponent.add(entity);
   VelocityComponent.add(entity, { x: 1, y: 2, z: 3 });
 
@@ -85,7 +85,8 @@ test("compose entities from components", () => {
 });
 
 test("remove entities from components", () => {
-  const entity = new BaseEntity();
+  const world = new World();
+  const entity = world.addEntity();
   SpriteComponent.add(entity);
 
   SpriteComponent.remove(entity);
@@ -96,13 +97,15 @@ test("remove entities from components", () => {
 });
 
 test("errors on adding non-conformer directly to entity set", () => {
-  const entity = new BaseEntity();
+  const world = new World();
+  const entity = world.addEntity();
   assert.throws(() => (SpriteComponent.entities as any).add(entity));
 });
 
 test("deserialize component", () => {
-  const entity = new BaseEntity();
-  const entity2 = new BaseEntity();
+  const world = new World();
+  const entity = world.addEntity();
+  const entity2 = world.addEntity();
 
   // the add method uses the deserialize method
   VelocityComponent.add(entity, { x: 1, y: 2, z: 3 });
@@ -122,7 +125,7 @@ test("deserialize component", () => {
   // deserializing happens before the `add` event
   const addSpy = test.mock.fn();
   VelocityComponent.entities.onAdd(addSpy);
-  VelocityComponent.add({}, { x: 9, y: 8, z: 7 });
+  VelocityComponent.add(world.addEntity(), { x: 9, y: 8, z: 7 });
   assert.equal(addSpy.mock.calls.length, 1);
   assert.deepEqual(addSpy.mock.calls[0].arguments[0], {
     velocity: new Vector3(9, 8, 7)
@@ -130,7 +133,8 @@ test("deserialize component", () => {
 });
 
 test("serialize component", () => {
-  const entity = new BaseEntity();
+  const world = new World();
+  const entity = world.addEntity();
   VelocityComponent.add(entity, { x: 1, y: 2, z: 3 });
 
   assert(VelocityComponent.has(entity));

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -5,6 +5,8 @@ import {
   ObservableSet
 } from "./Observable";
 import { isProduction, setDebugAlias } from "./Debug";
+import { EntityMeta } from "./EntityMeta";
+import type { IEntity } from "./EntityManager";
 
 export interface IReadonlyComponentDefinition<TCtor extends IConstructor<any>> {
   entities: IReadonlyObservableSet<InstanceType<TCtor>>;
@@ -39,7 +41,7 @@ export interface ISerializable<D> {
 
 export type EntityWithComponents<
   Components extends IReadonlyComponentDefinition<any>
-> = UnionToIntersection<HasComponent<{}, Components>>;
+> = UnionToIntersection<HasComponent<{}, Components>> & IEntity;
 
 function Serializable<Ctor extends IConstructor<any>, Data>(
   wrapperCtor: Ctor,
@@ -58,6 +60,7 @@ function Serializable<Ctor extends IConstructor<any>, Data>(
         data === undefined || (ctor !== undefined && "deserialize" in ctor),
         "This component does not define a deserialize method, so it cannot accept data parameters."
       );
+      invariant(EntityMeta.has(entity), `Entity is missing metadata`);
       if (isSerializable && data !== undefined) {
         serializableCtor.deserialize(entity, data);
         this.#deserializeObservable.next(data);

--- a/src/EntityManager.test.ts
+++ b/src/EntityManager.test.ts
@@ -1,5 +1,5 @@
 import { Vector3, Sprite } from "three";
-import { IEntity, World } from "./EntityManager";
+import { World } from "./EntityManager";
 import test from "node:test";
 import assert from "node:assert";
 import { getMock } from "./testHelpers";
@@ -34,14 +34,13 @@ interface IActor {
   behaviorId: string;
 }
 
-interface ISerializable<Data extends IEntity> {
+interface ISerializable<Data> {
   serialize(): Data;
   deserialize(data: Data): void;
 }
 
 interface ISpriteEntityJSON
-  extends IEntity,
-    IHasTexture,
+  extends IHasTexture,
     IMaybeVisible,
     IPositionable,
     IMovable,
@@ -72,7 +71,7 @@ class SpriteEntity implements IHasSprite, ISerializable<ISpriteEntityJSON> {
       velocity: this.velocity,
       spawned: this.spawned,
       behaviorId: this.behaviorId,
-      textureId: this.textureId,
+      textureId: this.textureId
     };
   }
   deserialize(data: ISpriteEntityJSON) {
@@ -91,7 +90,7 @@ test("adding entities", () => {
   const addEntitySpy = test.mock.fn();
   const addEntityMock = getMock(addEntitySpy);
   world.entities.onAdd(addEntitySpy);
-  const entity = world.addEntity(() => new SpriteEntity("mario"));
+  const entity = world.addEntity(() => new SpriteEntity("mario") as any);
 
   assert.equal(addEntityMock.calls.length, 1);
   assert.equal(addEntityMock.calls[0].arguments[0], entity);
@@ -102,7 +101,7 @@ test("removing entities", () => {
   const removeEntitySpy = test.mock.fn();
   const removeEntityMock = getMock(removeEntitySpy);
   world.entities.onRemove(removeEntitySpy);
-  const entity = world.addEntity(() => new SpriteEntity("mario"));
+  const entity = world.addEntity(() => new SpriteEntity("mario") as any);
   world.removeEntity(entity);
 
   assert.equal(removeEntityMock.calls.length, 1);
@@ -113,7 +112,7 @@ test("stream entities that have been or will be added", () => {
   const state = new World();
   const addEntitySpy = test.mock.fn();
   const addEntityMock = getMock(addEntitySpy);
-  const entity = state.addEntity(() => new SpriteEntity("mario"));
+  const entity = state.addEntity(() => new SpriteEntity("mario") as any);
   state.entities.stream(addEntitySpy);
   assert.equal(addEntityMock.calls.length, 1);
   assert.equal(addEntityMock.calls[0].arguments[0], entity);

--- a/src/EntityManager.ts
+++ b/src/EntityManager.ts
@@ -1,7 +1,9 @@
 import { IComponentDefinition } from "./Component";
+import { EntityMeta, IEntityWithMeta } from "./EntityMeta";
+import { invariant } from "./Error";
 import { IObservableSet, ObservableSet } from "./Observable";
 
-export interface IEntity {}
+export interface IEntity extends IEntityWithMeta<IComponentDefinition> {}
 
 export interface IEntityFactory<W extends IWorld, E extends IEntity> {
   (world: W): E;
@@ -26,7 +28,6 @@ export interface IWorld {
 // TODO default entity factory given in constructor?
 export class World {
   #entities = new ObservableSet<IEntity>();
-  #componentMap = new Map<IEntity, Set<IComponentDefinition<any>>>();
 
   get entities() {
     return this.#entities;
@@ -36,23 +37,27 @@ export class World {
     Entity extends IEntity,
     Factory extends IEntityFactory<this, Entity>
   >(Factory?: Factory): ReturnType<Factory> {
-    const entity = Factory ? Factory(this) : {};
+    const entity = Factory ? Factory(this) : ({} as IEntity);
+    EntityMeta.set(entity);
     this.#entities.add(entity);
-    this.#componentMap.set(entity, new Set());
     return entity as ReturnType<Factory>;
   }
 
   removeEntity(entity: IEntity) {
     this.#entities.remove(entity);
-    const set = this.#componentMap.get(entity)!;
-    for (const component of set) {
+    invariant(EntityMeta.has(entity), `Entity is missing metadata`);
+    const meta = EntityMeta.get(entity);
+
+    for (const component of meta.components) {
       component.remove(entity);
     }
   }
 
   registerComponent(component: IComponentDefinition<any>) {
     component.entities.onAdd((entity) => {
-      this.#componentMap.get(entity)!.add(component);
+      const meta = EntityMeta.get(entity);
+      invariant(!!meta, `Entity is missing metadata`);
+      meta.components.add(component);
     });
   }
 }

--- a/src/EntityMeta.ts
+++ b/src/EntityMeta.ts
@@ -1,0 +1,18 @@
+const ENTITY_META_PROPERTY = Symbol("entity_meta");
+
+export class EntityMeta<ComponentDefinition> {
+  components = new Set<ComponentDefinition>();
+  static has(entity: any) {
+    return ENTITY_META_PROPERTY in entity;
+  }
+  static set(entity: any, meta = new EntityMeta()) {
+    entity[ENTITY_META_PROPERTY] = meta;
+  }
+  static get(entity: any): EntityMeta<any> {
+    return entity[ENTITY_META_PROPERTY];
+  }
+}
+
+export interface IEntityWithMeta<ComponentDefinition> {
+  [ENTITY_META_PROPERTY]: EntityMeta<ComponentDefinition>;
+}

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -1,4 +1,8 @@
-import { IComponentDefinition, defineComponent } from "./Component";
+import {
+  EntityWithComponents,
+  IComponentDefinition,
+  defineComponent
+} from "./Component";
 import chalk from "chalk";
 import { World } from "./EntityManager";
 import { QueryManager } from "./Query";
@@ -243,8 +247,9 @@ profile("simulate (iterator, world)", () => {
       i++;
       if (!VelocityComponent.has(entity)) continue;
 
-      const { position, velocity } = entity as IPositionComponent &
-        IVelocityComponent;
+      const { position, velocity } = entity as EntityWithComponents<
+        typeof PositionComponent | typeof VelocityComponent
+      >;
       position.x += velocity.x;
       position.y += velocity.y;
       position.z += velocity.z;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,9 @@
 import { AnimationClip, Object3D } from "three";
-import { IComponentDefinition, defineComponent } from "../Component";
+import {
+  EntityWithComponents,
+  IComponentDefinition,
+  defineComponent
+} from "../Component";
 import { Action } from "../systems/ActionSystem";
 import { Animation, IAnimation, IAnimationJson } from "../Animation";
 import {
@@ -138,8 +142,10 @@ export const NameComponent: IComponentDefinition<
 
 interface IBehaviorComponent {
   behaviorId: string;
-  actions: Set<Action<this, any>>;
-  cancelledActions: Set<Action<this, any>>;
+  actions: Set<Action<EntityWithComponents<typeof BehaviorComponent>, any>>;
+  cancelledActions: Set<
+    Action<EntityWithComponents<typeof BehaviorComponent>, any>
+  >;
 }
 
 export const BehaviorComponent: IComponentDefinition<

--- a/src/systems/ActionSystem.test.ts
+++ b/src/systems/ActionSystem.test.ts
@@ -4,6 +4,7 @@ import { BehaviorComponent, ChangedTag } from "../components";
 import { MockState, getMock } from "../testHelpers";
 import assert from "node:assert";
 import { SystemManager } from "../System";
+import { World } from "../EntityManager";
 
 class MockAction extends Action<any, any> {
   constructor(entity: any, startTime: number, maxElapsedTime: number) {
@@ -14,7 +15,8 @@ class MockAction extends Action<any, any> {
 }
 
 test("processing pending actions", () => {
-  const entity = {};
+  const world = new World();
+  const entity = world.addEntity();
   const state = new MockState();
   const mgr = new SystemManager(state);
 
@@ -58,7 +60,8 @@ test("processing pending actions", () => {
 });
 
 test("undoing completed actions", () => {
-  const entity = {};
+  const world = new World();
+  const entity = world.addEntity();
   const state = new MockState();
   const mgr = new SystemManager(state);
   const { undoingActions, completedActions, pendingActions } = state;
@@ -123,9 +126,10 @@ test("undoing completed actions", () => {
 });
 
 test("handling directly and indirectly cancelled actions", () => {
-  const player = {};
-  const block1 = {};
-  const block2 = {};
+  const world = new World();
+  const player = world.addEntity();
+  const block1 = world.addEntity();
+  const block2 = world.addEntity();
   const state = new MockState();
   const mgr = new SystemManager(state);
   const { pendingActions, completedActions } = state;

--- a/src/systems/AnimationSystem.test.ts
+++ b/src/systems/AnimationSystem.test.ts
@@ -11,6 +11,7 @@ import {
 import { AnimationComponent, TransformComponent } from "../components";
 import { Texture } from "three";
 import { Image } from "../globals";
+import { World } from "../EntityManager";
 
 function setUp() {
   const state = new MockState();
@@ -38,7 +39,8 @@ const animation = new AnimationJson([
 
 test("using textures that haven't yet been loaded", () => {
   const { state, system } = setUp();
-  const spriteEntity = {};
+  const world = new World();
+  const spriteEntity = world.addEntity();
 
   AnimationComponent.add(spriteEntity, {
     animation
@@ -53,9 +55,10 @@ test("using textures that haven't yet been loaded", () => {
 
 test("using textures that have already been loaded", () => {
   const { state, system } = setUp();
+  const world = new World();
   const texture = new Texture(new Image() as any);
   state.addTexture("assets/texture.png", texture);
-  const entity = {};
+  const entity = world.addEntity();
   AnimationComponent.add(entity, {
     animation
   });
@@ -67,7 +70,8 @@ test("using textures that have already been loaded", () => {
 
 test("changing the clip index", () => {
   const { state, system } = setUp();
-  const entity = {};
+  const world = new World();
+  const entity = world.addEntity();
   AnimationComponent.add(entity, {
     animation
   });

--- a/src/systems/BehaviorSystem.test.ts
+++ b/src/systems/BehaviorSystem.test.ts
@@ -13,6 +13,7 @@ import { IObservableSet } from "../Observable";
 import { SystemManager } from "../System";
 import { Action } from "./ActionSystem";
 import { convertToPixels } from "../units/convert";
+import { World } from "../EntityManager";
 
 class MockAction extends Action<any, any> {
   constructor(entity: any, startTime: number, maxElapsedTime: number) {
@@ -33,6 +34,7 @@ test.afterEach(() => {
 });
 
 test("behaviors initiating actions", () => {
+  const world = new World();
   class MockBehavior extends Behavior<
     EntityWithComponents<typeof BehaviorComponent>,
     never
@@ -41,8 +43,8 @@ test("behaviors initiating actions", () => {
       return [new MockAction(entity, 0, 0), new MockAction(entity, 0, 0)];
     }
   }
-  const entityA = {};
-  const entityB = {};
+  const entityA = world.addEntity();
+  const entityB = world.addEntity();
   const state = new MockState();
   const mgr = new SystemManager(state);
   const system = new BehaviorSystem(mgr);
@@ -63,6 +65,7 @@ test("behaviors initiating actions", () => {
 });
 
 test("behaviors receiving and reacting to actions", () => {
+  const world = new World();
   class MockBehavior extends Behavior<
     EntityWithComponents<typeof BehaviorComponent>,
     never
@@ -92,8 +95,8 @@ test("behaviors receiving and reacting to actions", () => {
       );
     }
   }
-  const entityA = {};
-  const entityB = {};
+  const entityA = world.addEntity();
+  const entityB = world.addEntity();
   const state = new MockState();
   const mgr = new SystemManager(state);
   const system = new BehaviorSystem(mgr);

--- a/src/systems/RenderSystem.test.ts
+++ b/src/systems/RenderSystem.test.ts
@@ -5,6 +5,7 @@ import { AddedTag, TransformComponent } from "../components";
 import { MockState } from "../testHelpers";
 import { IObservableSet } from "../Observable";
 import { SystemManager } from "../System";
+import { World } from "../EntityManager";
 
 test.afterEach(() => {
   TransformComponent.clear();
@@ -15,8 +16,9 @@ test("it renders the scene", () => {
   const state = new MockState();
   const mgr = new SystemManager(state);
   const system = new RenderSystem(mgr);
+  const world = new World();
 
-  const entity = {};
+  const entity = world.addEntity();
 
   TransformComponent.add(entity);
   AddedTag.add(entity);
@@ -33,8 +35,9 @@ test("when sprites are added it adds them to the scene and renders", () => {
   const state = new MockState() as any;
   const mgr = new SystemManager(state);
   const system = new RenderSystem(mgr);
+  const world = new World();
 
-  const spriteEntity = {};
+  const spriteEntity = world.addEntity();
   TransformComponent.add(spriteEntity);
   AddedTag.add(spriteEntity);
 
@@ -51,8 +54,9 @@ test("when sprites are removed it removes them from the scene and renders", () =
   const state = new MockState();
   const mgr = new SystemManager(state);
   const system = new RenderSystem(mgr);
+  const world = new World();
 
-  const spriteEntity = {};
+  const spriteEntity = world.addEntity();
   TransformComponent.add(spriteEntity);
   AddedTag.add(spriteEntity);
 
@@ -68,8 +72,9 @@ test("it renders when entities are changing", () => {
   const state = new MockState();
   const mgr = new SystemManager(state);
   const system = new RenderSystem(mgr);
+  const world = new World();
 
-  const entity = {};
+  const entity = world.addEntity();
   TransformComponent.add(entity);
   AddedTag.add(entity);
 


### PR DESCRIPTION
Store entity meta data (which for now merely consists of the set of components that have the entity) within the entity object itself. These just feels like a better architecture and hopefully it will fix this hard-to-reproduce server crash.