### PR TITLE
remove unnecessary block misalignment measure

### DIFF
--- a/src/entities/BlockEntity.ts
+++ b/src/entities/BlockEntity.ts
@@ -51,13 +51,6 @@ export class BlockBehavior extends Behavior<any, any> {
     const pushes = [];
     const pushesFromNonBlocks = [];
 
-    let moveInProgress = false;
-    for (const action of entity.actions) {
-      if (action instanceof MoveAction) {
-        moveInProgress = true;
-      }
-    }
-
     for (const action of actions) {
       if (action instanceof PushAction) {
         pushes.push(action);
@@ -68,7 +61,7 @@ export class BlockBehavior extends Behavior<any, any> {
         pushesFromNonBlocks.push(action);
       }
     }
-    if (pushesFromNonBlocks.length > 0 && !moveInProgress) {
+    if (pushesFromNonBlocks.length > 0) {
       const move = new MoveAction(
         entity,
         context.time,


### PR DESCRIPTION
The change to consider entities between tiles as occupying both tiles solves this same sub-problem, but better.