### PR TITLE
use messages for inter-entity comm & rewrite action system

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,17 @@
     <noscript><h1>Sorry, but JavaScript must be <a href="https://www.wikihow.com/Enable-JavaScript">enabled</a> to play.</h1></noscript>
     <div class="canvasShrinkwrap">
       <div id="uiRootElement" class="positionAbsolute layer2 fillAndExpand">
+        <form class="top right positionAbsolute layer1" id="devVarsForm">
+          <label class="displayBlock">
+            <input id="timeScaleInput" type="number" step="0.1" value="1" min="0.1" max="10"> time scale
+          </label>
+          <label class="displayBlock">
+            <input id="moveTimeInput" type="number" step="1" value="200" min="1" max="2000"> move time (ms)
+          </label>
+          <label class="displayBlock">
+            <input id="turnTimeInput" type="number" step="1" value="30" min="1" max="2000"> turn time (ms)
+          </label>
+        </form>
       </div>
       <canvas id="canvas" class="top left positionAbsolute displayBlock fullWidth fullHeight"></canvas>
       <div id="winMessageElement" class="positionAbsolute fullWidth fullHeight displayNone layer1 pointerEventsNone">
@@ -46,17 +57,6 @@
       </div>
     </div>
 
-    <form class="top right positionAbsolute layer1" id="devVarsForm">
-      <label class="displayBlock">
-        <input id="timeScaleInput" type="number" step="0.1" value="1" min="0.1" max="10"> time scale
-      </label>
-      <label class="displayBlock">
-        <input id="moveTimeInput" type="number" step="1" value="200" min="1" max="2000"> move time (ms)
-      </label>
-      <label class="displayBlock">
-        <input id="turnTimeInput" type="number" step="1" value="30" min="1" max="2000"> turn time (ms)
-      </label>
-    </form>
 
 
     <section id="signInForm">

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview an application of the command pattern. I just like the word "action" better.
+ *
+ * Motivation: support undo/redo.
+ *
+ * Rules of Actions:
+ *  - All state mutation should be done through actions.
+ *  - Once an action is added to the queue, it will be applied in the current frame.
+ *  - Actions should be regarded as immutable.
+ *  - The action does what it says. Keep it simple.
+ *  - Avoid control flow statements (if, switch, for, while...) in actions.
+ *     - Instead, make sure that only the appropriate actions are added to the queue.
+ *
+ */
+
+import { EntityWithComponents } from "./Component";
+import { BehaviorComponent } from "./components";
+
+/** Objects of Action! Grrr... */
+export abstract class Action<
+  Entity extends EntityWithComponents<typeof BehaviorComponent>,
+  Context
+> {
+  static nextId = 0;
+  static MAX_HISTORY = 1200;
+  id = Action.nextId++;
+  constructor(
+    readonly entity: Entity,
+    readonly startTime: number,
+    readonly maxElapsedTime: number
+  ) {}
+  abstract update(context: Context): void;
+  #progress = 0;
+  get progress() {
+    return this.#progress;
+  }
+  onStart() {
+    this.entity.actions.add(this);
+  }
+  onComplete() {
+    this.entity.actions.delete(this);
+  }
+  seek(deltaTime: number) {
+    this.#progress = Math.max(
+      0,
+      Math.min(1, this.progress + deltaTime / this.maxElapsedTime)
+    );
+  }
+  canUndo = true;
+  humanName = this.constructor.name;
+  toString() {
+    return `${this.humanName} (${this.id}) startTime: ${this.startTime} endTime: ${this.endTime}`;
+  }
+  occursAtTime(time: number) {
+    const { startTime, endTime } = this;
+    return startTime < time && endTime > time;
+  }
+  get endTime() {
+    return this.startTime + this.maxElapsedTime;
+  }
+  overlaps(action: Action<any, any>) {
+    return (
+      this.occursAtTime(action.startTime) || this.occursAtTime(action.endTime)
+    );
+  }
+}

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -27,6 +27,9 @@ export interface IComponentDefinition<
     data?: Data
   ): asserts entity is E & InstanceType<TCtor>;
   remove<E extends {}>(entity: E): Omit<E, keyof InstanceType<TCtor>>;
+  onRemove<E extends EntityWithComponents<this>>(
+    callback: (entity: E) => void
+  ): void;
   serialize<E extends {}>(entity: E & InstanceType<TCtor>, target?: any): Data;
   /** remove all entities from this component */
   clear(): void;
@@ -148,11 +151,16 @@ export function defineComponent<
         return true;
       }
       remove<E extends {}>(entity: E & InstanceType<Ctor>) {
+        this.#removeObservable.next(entity);
         this.entities.remove(entity);
         for (const key in this.#proto) {
           delete entity[key];
         }
         return entity;
+      }
+      #removeObservable = new Observable<any>();
+      onRemove(callback: (entity: any) => void) {
+        this.#removeObservable.subscribe(callback);
       }
       has<E extends {}>(entity: E): entity is E & InstanceType<Ctor> {
         return this.entities.has(entity as E & InstanceType<Ctor>);

--- a/src/EntityManager.ts
+++ b/src/EntityManager.ts
@@ -26,7 +26,7 @@ export interface IWorld {
 }
 
 // TODO default entity factory given in constructor?
-export class World {
+export class World implements IWorld {
   #entities = new ObservableSet<IEntity>();
 
   get entities() {

--- a/src/HeadingDirection.ts
+++ b/src/HeadingDirection.ts
@@ -1,4 +1,4 @@
-import { Vector2 } from "three";
+import { Vector3 } from "three";
 import { convertToPixels } from "./units/convert";
 import { invariant } from "./Error";
 
@@ -18,18 +18,36 @@ enum HeadingDirectionRadians {
 }
 
 export class HeadingDirection {
-  static getVector(direction: HeadingDirectionValue, target = new Vector2()) {
+  static fromXY(x: number, y: number) {
+    if (x > 0 && y === 0) {
+      return HeadingDirectionValue.Right;
+    }
+    if (x < 0 && y === 0) {
+      return HeadingDirectionValue.Left;
+    }
+    if (x === 0 && y > 0) {
+      return HeadingDirectionValue.Down;
+    }
+    if (x === 0 && y < 0) {
+      return HeadingDirectionValue.Up;
+    }
+    throw `Not a HeadingDirectionValue: ${x}, ${y}`;
+  }
+  static fromVector({ x, y }: Vector3) {
+    return this.fromXY(x, y);
+  }
+  static getVector(direction: HeadingDirectionValue, target = new Vector3()) {
     switch (direction) {
       case HeadingDirectionValue.Up:
-        return target.set(0, convertToPixels(1 as Tile));
+        return target.set(0, convertToPixels(1 as Tile), 0);
       case HeadingDirectionValue.Down:
-        return target.set(0, convertToPixels(-1 as Tile));
+        return target.set(0, convertToPixels(-1 as Tile), 0);
       case HeadingDirectionValue.Left:
-        return target.set(convertToPixels(-1 as Tile), 0);
+        return target.set(convertToPixels(-1 as Tile), 0, 0);
       case HeadingDirectionValue.Right:
-        return target.set(convertToPixels(1 as Tile), 0);
+        return target.set(convertToPixels(1 as Tile), 0, 0);
       case HeadingDirectionValue.None:
-        return target.set(0, 0);
+        return target.set(0, 0, 0);
       default:
         invariant(false, `Invalid direction: ${direction}`);
     }

--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -21,7 +21,7 @@ export class Matrix<T> {
     }
     return value;
   }
-  get(x: number, y: number): T {
+  get(x: number, y: number): T | undefined {
     assertInts(x, y);
     return this.#data[y]?.[x];
   }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,0 +1,141 @@
+import { invariant } from "./Error";
+import { BehaviorState } from "./state";
+
+interface IActor {
+  behaviorId: string;
+}
+
+export interface IMessageReceiver extends IActor {
+  inbox: MessageInstanceMap;
+}
+
+export interface IMessageSender extends IActor {
+  outbox: MessageInstanceMap;
+}
+
+export class MessageInstanceMap {
+  #map = new Map<IConstructor<any>, Set<Message<any>>>();
+  add<PMessage extends Message<any>>(
+    msgType: IConstructor<PMessage>,
+    ...msgs: PMessage[]
+  ) {
+    const map = this.#map;
+    const set = map.get(msgType) ?? new Set();
+    for (const msg of msgs) {
+      set.add(msg);
+    }
+    map.set(msgType, set);
+  }
+  getAll<PMessage extends Message<any>>(msgType: IConstructor<PMessage>) {
+    const map = this.#map;
+    let result = map.get(msgType) as Set<PMessage>;
+    if (!result) {
+      result = new Set();
+      map.set(msgType, result);
+    }
+    return result;
+  }
+  clear() {
+    this.#map.clear();
+  }
+  get size() {
+    return this.#map.size;
+  }
+}
+
+const nilReceiver: IMessageReceiver = {
+  behaviorId: "",
+  inbox: new MessageInstanceMap()
+};
+
+const nilSender: IMessageSender = {
+  behaviorId: "",
+  outbox: new MessageInstanceMap()
+};
+
+export class Message<Answer> {
+  constructor(
+    readonly receiver: IMessageReceiver,
+    readonly sender: IMessageSender,
+    readonly id = Message.getNextId()
+  ) {}
+  toString() {
+    return this.constructor.name;
+  }
+  answer: Answer | TMessageNoAnswer = Message.noAnswer;
+  static nextId = 0;
+  static getNextId() {
+    return this.nextId++;
+  }
+  static empty = new Message(nilReceiver, nilSender);
+  static noAnswer = Symbol("noAnswer");
+}
+
+type TBuilderHiddenFields = "sender" | "receiver" | "MessageCtor" | "ctorArgs";
+
+const builder = {
+  sender: nilSender,
+  receiver: nilReceiver,
+  MessageCtor: Message as IConstructor<Message<any>>,
+  ctorArgs: [] as any[],
+  from(sender: IMessageSender) {
+    this.sender = sender;
+    return this as Omit<typeof builder, "from" | TBuilderHiddenFields>;
+  },
+  to(receiver: IMessageReceiver) {
+    const { sender, MessageCtor } = this;
+    invariant(sender !== nilSender, `Expected sender to have been provided`);
+    return new MessageCtor(receiver, sender, ...this.ctorArgs);
+  }
+};
+
+type Slice<T extends any[]> = T extends [any, any, ...infer Rest]
+  ? Rest
+  : never;
+
+export function createMessage<
+  PMessageConstructor extends IConstructor<Message<any>>
+>(
+  MessageCtor: PMessageConstructor,
+  ...args: Slice<ConstructorParameters<PMessageConstructor>>
+) {
+  builder.MessageCtor = MessageCtor;
+  builder.ctorArgs = args;
+  return builder as Omit<typeof builder, "to" | TBuilderHiddenFields>;
+}
+
+export type TMessageNoAnswer = (typeof Message)["noAnswer"];
+
+export function sendMessage<PAnswer>(
+  msg: Message<PAnswer>,
+  context: BehaviorState
+): PAnswer | TMessageNoAnswer {
+  const { receiver, sender } = msg;
+
+  const behavior = context.getBehavior(receiver.behaviorId);
+  behavior.onReceive(msg, receiver, context);
+  receiver.inbox.add(msg.constructor as any, msg);
+  sender.outbox.add(msg.constructor as any, msg);
+
+  return msg.answer;
+}
+
+export function hasAnswer<Answer>(box: Set<Message<Answer>>, answer: Answer) {
+  for (const msg of box) {
+    if (msg.answer === answer) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getMessageWithAnswer<PMessage extends Message<any>>(
+  box: Set<PMessage>,
+  answer: PMessage extends Message<infer Answer> ? Answer : never
+) {
+  for (const msg of box) {
+    if (msg.answer === answer) {
+      return msg;
+    }
+  }
+}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -172,6 +172,19 @@ export class ObservableArray<T> {
     return value;
   }
 
+  unshift(value: T) {
+    this.#array.unshift(value);
+    this.#addObs.next(value);
+  }
+
+  shift() {
+    const value = this.#array.shift();
+    if (value) {
+      this.#removeObs.next(value);
+    }
+    return value;
+  }
+
   at(index: number) {
     return this.#array.at(index);
   }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -100,32 +100,33 @@ class QueryResults<
       component.entities.stream((entity) => {
         if (this.has(entity)) {
           if (this.debug) {
-            console.log("added", (entity as any).name, "to", this.toString());
+            console.log("added", component.toString(), "to", this.toString());
           }
           this.#entities.add(entity);
         }
       });
       component.entities.onRemove((entity) => {
-        if (this.debug) {
-          console.log(
-            "removed",
-            (entity as any).name,
-            "from",
-            component.toString()
-          );
-        }
+        const { debug } = this;
+        // if (debug) {
+        //   console.log(
+        //     "removed",
+        //     (entity as any).name,
+        //     "from",
+        //     component.toString()
+        //   );
+        // }
         if (this.#entities.has(entity) && !this.has(entity)) {
-          if (this.debug) {
-            console.log(
-              "removed",
-              (entity as any).name,
-              "from",
-              this.toString()
-            );
-          }
-          if ("op" in component && component.op === "not") {
+          if ((component as Operand<any>).op === "not") {
             this.#entities.add(entity);
           } else {
+            if (debug) {
+              console.log(
+                "removed",
+                component.toString(),
+                "from query",
+                this.toString()
+              );
+            }
             this.#entities.remove(entity);
           }
         }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -4,23 +4,21 @@ import {
   RendererState,
   TimeState
 } from "../state";
-import { Action, ActionEntity } from "../systems/ActionSystem";
+import { Action } from "../Action";
+import { ActionEntity } from "../systems/ActionSystem";
 import {
   AddedTag,
   AnimationComponent,
-  ChangedTag,
   HeadingDirectionComponent,
-  TransformComponent,
-  VelocityComponent
+  TransformComponent
 } from "../components";
-import { Vector2, Vector3 } from "three";
+import { Vector3 } from "three";
 import { IEntityPrefab } from "../EntityManager";
 import { ITypewriterCursor } from "../Typewriter";
 import { HeadingDirection, HeadingDirectionValue } from "../HeadingDirection";
 import { EntityWithComponents } from "../Component";
 import { removeElementByIdSafely } from "../UIElement";
 import { afterDOMContentLoaded } from "../util";
-import { convertToPixels } from "../units/convert";
 
 declare const moveTimeInput: HTMLInputElement;
 function getMoveTimeFromInput() {
@@ -44,34 +42,22 @@ if (globalThis.document !== undefined) {
   });
 }
 
-export class MoveAction extends Action<
-  ActionEntity<typeof TransformComponent | typeof VelocityComponent>,
-  TimeState
-> {
-  start = new Vector2();
-  delta = new Vector2();
-  SPEED_X: number;
-  SPEED_Y: number;
-  constructor(
-    entity: ActionEntity<typeof TransformComponent | typeof VelocityComponent>,
-    startTime: number,
-    headingDirection: HeadingDirectionValue
-  ) {
+export class MoveAction<
+  Entity extends ActionEntity<typeof TransformComponent>
+> extends Action<Entity, TimeState> {
+  readonly start = new Vector3();
+  readonly delta = new Vector3();
+  constructor(entity: Entity, startTime: number, delta: Vector3) {
     super(entity, startTime, getMoveTime());
-    const { start, delta } = this;
+    const { start } = this;
     const { position } = entity.transform;
-    HeadingDirection.getVector(headingDirection, delta);
     start.copy(position);
-    const SPEED = convertToPixels(1 as Tile) / this.maxElapsedTime;
-    this.SPEED_X = Math.sign(delta.x) * SPEED;
-    this.SPEED_Y = Math.sign(delta.y) * SPEED;
+    this.delta.copy(delta);
   }
   update(): void {
-    const { entity, delta, progress, start, SPEED_X, SPEED_Y } = this;
-    const { velocity, transform } = entity;
+    const { entity, delta, progress, start } = this;
+    const { transform } = entity;
     const { position } = transform;
-
-    velocity.set(SPEED_X, SPEED_Y, 0);
 
     position.set(
       start.x + delta.x * progress,
@@ -79,9 +65,10 @@ export class MoveAction extends Action<
       position.z
     );
   }
+  humanName = "Move";
   toString(): string {
     const { delta } = this;
-    return `Move by ${delta.x}, ${delta.y}`;
+    return `${super.toString()} x: ${delta.x} y: ${delta.y}`;
   }
 }
 
@@ -128,44 +115,23 @@ export class RotateAction extends Action<
       entity.headingDirection = initial;
     }
   }
+  humanName = "Rotate";
   toString(): string {
-    return `Rotate ${HeadingDirection.stringify(this.target)}`;
+    return `${super.toString()} direction: ${HeadingDirection.stringify(this.target)}`;
   }
 }
 
-export class PushAction extends Action<
-  ActionEntity<typeof TransformComponent>,
-  TimeState
-> {
-  constructor(
-    entity: ActionEntity<typeof TransformComponent>,
-    startTime: number,
-    readonly delta: Vector2
-  ) {
-    super(entity, startTime, 0);
-    const { position } = this.entity.transform;
-    this.addEffectedTile(position.x + delta.x, position.y + delta.y);
-  }
-  update() {}
-  toString(): string {
-    const [end] = this.listEffectedTiles();
-    return `Push to ${end.x}, ${end.y}`;
-  }
-}
-
-export class CreateEntityAction extends Action<
-  ActionEntity<typeof TransformComponent>,
-  EntityManagerState
-> {
+export class CreateEntityAction<
+  Entity extends ActionEntity<typeof TransformComponent>
+> extends Action<Entity, EntityManagerState> {
   #createdEntity?: any;
   constructor(
-    entity: ActionEntity<typeof TransformComponent>,
+    entity: Entity,
     startTime: number,
     readonly prefab: IEntityPrefab<any>,
     readonly position: ReadonlyRecursive<Vector3>
   ) {
     super(entity, startTime, 0);
-    this.addEffectedTile(position.x, position.y);
   }
   update(state: EntityManagerState) {
     const { prefab, position } = this;
@@ -174,7 +140,6 @@ export class CreateEntityAction extends Action<
       if (TransformComponent.has(createdEntity)) {
         createdEntity.transform.position.copy(position);
       }
-      ChangedTag.add(createdEntity);
       this.#createdEntity = createdEntity;
     } else {
       prefab.destroy(this.#createdEntity);
@@ -183,13 +148,14 @@ export class CreateEntityAction extends Action<
   }
 }
 
-export class SetAnimationClipIndexAction extends Action<
-  ActionEntity<typeof TransformComponent | typeof AnimationComponent>,
-  {}
-> {
+export class SetAnimationClipIndexAction<
+  Entity extends ActionEntity<
+    typeof TransformComponent | typeof AnimationComponent
+  >
+> extends Action<Entity, {}> {
   #previousClipIndex?: number;
   constructor(
-    entity: ActionEntity<typeof TransformComponent | typeof AnimationComponent>,
+    entity: Entity,
     startTime: number,
     readonly clipIndex: number
   ) {
@@ -206,14 +172,11 @@ export class SetAnimationClipIndexAction extends Action<
   }
 }
 
-export class ControlCameraAction extends Action<
-  ActionEntity<typeof TransformComponent>,
-  CameraState
-> {
-  constructor(
-    entity: ActionEntity<typeof TransformComponent>,
-    startTime: number
-  ) {
+export class ControlCameraAction<
+  Entity extends ActionEntity<typeof TransformComponent>
+> extends Action<Entity, CameraState> {
+  canUndo = false;
+  constructor(entity: Entity, startTime: number) {
     super(entity, startTime, 0);
   }
   update(state: CameraState) {
@@ -225,12 +188,11 @@ export class ControlCameraAction extends Action<
   }
 }
 
-export class RemoveEntityAction extends Action<
-  ActionEntity<typeof TransformComponent>,
-  {}
-> {
+export class RemoveEntityAction<
+  Entity extends ActionEntity<typeof TransformComponent>
+> extends Action<Entity, {}> {
   constructor(
-    entity: ActionEntity<typeof TransformComponent>,
+    entity: Entity,
     startTime: number,
     readonly entityToRemove: EntityWithComponents<any>
   ) {
@@ -240,10 +202,8 @@ export class RemoveEntityAction extends Action<
     const { entityToRemove } = this;
     if (this.progress > 0) {
       AddedTag.remove(entityToRemove);
-      ChangedTag.add(entityToRemove);
     } else {
       AddedTag.add(entityToRemove);
-      ChangedTag.add(entityToRemove);
     }
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,7 +5,7 @@ import {
   startFrameRhythms
 } from "./Rhythm";
 import {
-  BehaviorCacheState,
+  BehaviorState,
   EntityManagerState,
   State,
   TimeState,
@@ -130,7 +130,7 @@ if (process.env.NODE_ENV === "production") {
   }
 };
 
-function addStaticResources(state: BehaviorCacheState & TypewriterState) {
+function addStaticResources(state: BehaviorState & TypewriterState) {
   state.addBehavior(PlayerBehavior.id, new PlayerBehavior());
   state.addBehavior(BlockBehavior.id, new BlockBehavior());
   state.addBehavior(MonsterBehavior.id, new MonsterBehavior());

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-import { AnimationClip, Object3D } from "three";
+import { AnimationClip, Object3D, Vector3 } from "three";
 import {
   EntityWithComponents,
   IComponentDefinition,
@@ -181,9 +181,9 @@ interface ITransformComponent {
 }
 
 interface ITransformJson {
-  position: { x: number; y: number; z: number };
-  rotation: { x: number; y: number; z: number };
-  scale: { x: number; y: number; z: number };
+  position: ITriad;
+  rotation: ITriad;
+  scale: ITriad;
   visible: boolean;
 }
 
@@ -265,6 +265,42 @@ export const TransformComponent: IComponentDefinition<
       };
 
       return target;
+    }
+  }
+);
+
+interface IVelocityComponent {
+  velocity: Vector3;
+}
+
+interface IVelocityComponentJson {
+  velocity: ITriad;
+}
+
+export const VelocityComponent: IComponentDefinition<
+  IVelocityComponentJson,
+  new () => IVelocityComponent
+> = defineComponent(
+  class VelocityComponent {
+    velocity = new Vector3();
+
+    static deserialize<E extends IVelocityComponent>(
+      entity: E,
+      data: IVelocityComponentJson
+    ) {
+      Object.assign(entity.velocity, data.velocity);
+    }
+
+    static canDeserialize(data: any) {
+      return typeof data === "object" && "velocity" in data;
+    }
+
+    static serialize<E extends IVelocityComponent>(
+      entity: E,
+      target: IVelocityComponentJson
+    ) {
+      target.velocity ??= { x: 0, y: 0, z: 0 };
+      Object.assign(target.velocity, entity.velocity);
     }
   }
 );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,18 @@ import { MonsterEntity } from "./entities/MonsterEntity";
 import { HeadingDirectionValue } from "./HeadingDirection";
 import { RoosterEntity } from "./entities/RoosterEntity";
 import { WallEntity } from "./entities/WallEntity";
+import {
+  AddedTag,
+  AnimationComponent,
+  BehaviorComponent,
+  HeadingDirectionComponent,
+  IsActiveTag,
+  IsGameEntityTag,
+  ModelComponent,
+  ServerIdComponent,
+  TransformComponent,
+  VelocityComponent
+} from "./components";
 
 export const ENV = process.env.NODE_ENV as
   | "development"
@@ -67,3 +79,16 @@ export const BLOCK_HEIGHT = 64;
 
 export const SESSION_COOKIE_NAME = "session";
 export const MAX_SESSION_DURATION = 60 * 60 * 24; // 1 day
+
+export const NETWORK_COMPONENTS = [
+  ServerIdComponent,
+  TransformComponent,
+  AnimationComponent,
+  ModelComponent,
+  BehaviorComponent,
+  HeadingDirectionComponent,
+  IsActiveTag,
+  IsGameEntityTag,
+  AddedTag,
+  VelocityComponent
+];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,8 +16,8 @@ import {
   IsGameEntityTag,
   ModelComponent,
   ServerIdComponent,
-  TransformComponent,
-  VelocityComponent
+  TilePositionComponent,
+  TransformComponent
 } from "./components";
 
 export const ENV = process.env.NODE_ENV as
@@ -83,12 +83,12 @@ export const MAX_SESSION_DURATION = 60 * 60 * 24; // 1 day
 export const NETWORK_COMPONENTS = [
   ServerIdComponent,
   TransformComponent,
+  TilePositionComponent,
   AnimationComponent,
   ModelComponent,
   BehaviorComponent,
   HeadingDirectionComponent,
   IsActiveTag,
   IsGameEntityTag,
-  AddedTag,
-  VelocityComponent
+  AddedTag
 ];

--- a/src/entities/BlockEntity.ts
+++ b/src/entities/BlockEntity.ts
@@ -8,11 +8,12 @@ import {
   IdComponent,
   IsGameEntityTag,
   ModelComponent,
-  TransformComponent
+  TransformComponent,
+  VelocityComponent
 } from "../components";
 import { ASSETS } from "../constants";
 import { BehaviorCacheState, EntityManagerState, TimeState } from "../state";
-import { Action } from "../systems/ActionSystem";
+import { Action, ActionEntity } from "../systems/ActionSystem";
 import { Behavior } from "../systems/BehaviorSystem";
 import { HeadingDirectionValue } from "../HeadingDirection";
 
@@ -44,10 +45,7 @@ export class BlockBehavior extends Behavior<any, any> {
     entity: ReturnType<typeof BlockEntity.create>,
     context: TimeState
   ) {
-    const returnedActions: Action<
-      ReturnType<typeof BlockEntity.create>,
-      any
-    >[] = [];
+    const returnedActions: Action<ActionEntity<any>, any>[] = [];
     const pushes = [];
     const pushesFromNonBlocks = [];
 
@@ -95,7 +93,11 @@ export class BlockBehavior extends Behavior<any, any> {
 type Context = EntityManagerState & BehaviorCacheState;
 export const BlockEntity: IEntityPrefab<
   Context,
-  EntityWithComponents<typeof BehaviorComponent | typeof TransformComponent>
+  EntityWithComponents<
+    | typeof BehaviorComponent
+    | typeof TransformComponent
+    | typeof VelocityComponent
+  >
 > = {
   create(state) {
     const entity = state.addEntity();
@@ -111,6 +113,8 @@ export const BlockEntity: IEntityPrefab<
     });
 
     TransformComponent.add(entity);
+
+    VelocityComponent.add(entity);
 
     IsGameEntityTag.add(entity);
 

--- a/src/entities/CursorEntity.ts
+++ b/src/entities/CursorEntity.ts
@@ -6,7 +6,8 @@ import {
   AnimationComponent,
   BehaviorComponent,
   RenderOptionsComponent,
-  TransformComponent
+  TransformComponent,
+  VelocityComponent
 } from "../components";
 import { ASSETS, KEY_MAPS } from "../constants";
 import {
@@ -125,6 +126,7 @@ export const CursorEntity: IEntityPrefab<
     | typeof BehaviorComponent
     | typeof TransformComponent
     | typeof AnimationComponent
+    | typeof VelocityComponent
   >
 > = {
   create(state) {
@@ -167,6 +169,8 @@ export const CursorEntity: IEntityPrefab<
     });
 
     TransformComponent.add(entity);
+
+    VelocityComponent.add(entity);
 
     RenderOptionsComponent.add(entity, {
       renderOrder: 1,

--- a/src/entities/CursorEntity.ts
+++ b/src/entities/CursorEntity.ts
@@ -6,12 +6,12 @@ import {
   AnimationComponent,
   BehaviorComponent,
   RenderOptionsComponent,
-  TransformComponent,
-  VelocityComponent
+  TilePositionComponent,
+  TransformComponent
 } from "../components";
 import { ASSETS, KEY_MAPS } from "../constants";
 import {
-  BehaviorCacheState,
+  BehaviorState,
   CameraState,
   EntityManagerState,
   InputState,
@@ -20,7 +20,6 @@ import {
   TilesState,
   TimeState
 } from "../state";
-import { Action } from "../systems/ActionSystem";
 import { Behavior } from "../systems/BehaviorSystem";
 import {
   ControlCameraAction,
@@ -36,18 +35,22 @@ import {
   AnimationJson,
   KeyframeTrackJson
 } from "../Animation";
+import { HeadingDirection } from "../HeadingDirection";
 
-type Context = InputState & CameraState & TilesState & TimeState & MetaState;
+type Entity = ReturnType<typeof CursorEntity.create>;
+type Context = InputState &
+  CameraState &
+  TilesState &
+  TimeState &
+  MetaState &
+  EntityManagerState;
 
-export class CursorBehavior extends Behavior<
-  ReturnType<typeof CursorEntity.create>,
-  Context
-> {
+export class CursorBehavior extends Behavior<Entity, Context> {
   id = "behavior/cursor";
-  onEnter(entity: ReturnType<typeof CursorEntity.create>, context: Context) {
+  onEnter(entity: Entity, context: Context) {
     return [new ControlCameraAction(entity, context.time)];
   }
-  onUpdate(entity: ReturnType<typeof CursorEntity.create>, context: Context) {
+  onUpdateLate(entity: Entity, context: Context) {
     if (entity.actions.size > 0) {
       return;
     }
@@ -64,12 +67,12 @@ export class CursorBehavior extends Behavior<
             context.metaStatus = MetaStatus.Replace;
             return [new SetAnimationClipIndexAction(entity, time, 1)];
           case Key.x: {
-            const entsUnderCursor = context.tiles.get(
+            const nttUnderCursor = context.tiles.get(
               convertToTiles(position.x),
               convertToTiles(position.y)
             );
-            if (entsUnderCursor !== undefined) {
-              return [new RemoveEntityAction(entity, time, entsUnderCursor[0])];
+            if (nttUnderCursor !== undefined) {
+              return [new RemoveEntityAction(entity, time, nttUnderCursor)];
             }
             break;
           }
@@ -78,7 +81,7 @@ export class CursorBehavior extends Behavior<
               const move = new MoveAction(
                 entity,
                 time,
-                KEY_MAPS.MOVE[inputPressed as Key]
+                HeadingDirection.getVector(KEY_MAPS.MOVE[inputPressed as Key])
               );
               return [move];
             }
@@ -94,13 +97,12 @@ export class CursorBehavior extends Behavior<
               const prefab = KEY_MAPS.CREATE_PREFEB[inputPressed as Key];
               const tileX = convertToTiles(position.x);
               const tileY = convertToTiles(position.y);
-              const nttsAreUnderCursor = context.tiles.has(tileX, tileY);
-              const entsUnderCursor = context.tiles.get(tileX, tileY);
+              const nttUnderCursor = context.tiles.get(tileX, tileY);
               context.metaStatus = MetaStatus.Edit;
               return [
                 new SetAnimationClipIndexAction(entity, time, 0),
-                ...(nttsAreUnderCursor
-                  ? [new RemoveEntityAction(entity, time, entsUnderCursor[0])]
+                ...(nttUnderCursor !== undefined
+                  ? [new RemoveEntityAction(entity, time, nttUnderCursor)]
                   : []),
                 new CreateEntityAction(
                   entity,
@@ -113,20 +115,14 @@ export class CursorBehavior extends Behavior<
         }
     }
   }
-  onReceive(
-    actions: ReadonlyArray<Action<ReturnType<typeof CursorEntity.create>, any>>
-  ) {
-    void actions;
-  }
 }
 
 export const CursorEntity: IEntityPrefab<
-  BehaviorCacheState & EntityManagerState,
+  BehaviorState & EntityManagerState,
   EntityWithComponents<
     | typeof BehaviorComponent
     | typeof TransformComponent
     | typeof AnimationComponent
-    | typeof VelocityComponent
   >
 > = {
   create(state) {
@@ -170,7 +166,7 @@ export const CursorEntity: IEntityPrefab<
 
     TransformComponent.add(entity);
 
-    VelocityComponent.add(entity);
+    TilePositionComponent.add(entity);
 
     RenderOptionsComponent.add(entity, {
       renderOrder: 1,

--- a/src/entities/MonsterEntity.ts
+++ b/src/entities/MonsterEntity.ts
@@ -13,7 +13,8 @@ import {
   HeadingDirectionComponent,
   IsGameEntityTag,
   ModelComponent,
-  TransformComponent
+  TransformComponent,
+  VelocityComponent
 } from "../components";
 import { ASSETS } from "../constants";
 import {
@@ -37,7 +38,7 @@ export class MonsterBehavior extends Behavior<
   static id = "behavior/monster";
   #log = new Log("Monster");
   onEnter(
-    _entity: ActionEntity<typeof TransformComponent>,
+    _entity: ReturnType<typeof MonsterEntity.create>,
     context: BehaviorContext
   ) {
     context.logs.addLog(this.#log);
@@ -77,14 +78,10 @@ export class MonsterBehavior extends Behavior<
     actions: ReadonlyArray<Action<ReturnType<typeof MonsterEntity.create>, any>>
   ) {
     // TODO behavior composition
-    const pushes = [];
     for (const action of actions) {
       if (action instanceof PushAction) {
-        pushes.push(action);
+        action.cancelled = true;
       }
-    }
-    for (const action of pushes) {
-      action.cancelled = true;
     }
   }
 }
@@ -96,6 +93,7 @@ export const MonsterEntity: IEntityPrefab<
     | typeof BehaviorComponent
     | typeof TransformComponent
     | typeof HeadingDirectionComponent
+    | typeof VelocityComponent
   >
 > = {
   create(state) {
@@ -106,6 +104,8 @@ export const MonsterEntity: IEntityPrefab<
     });
 
     TransformComponent.add(entity);
+
+    VelocityComponent.add(entity);
 
     ModelComponent.add(entity, {
       modelId: ASSETS.monster

--- a/src/entities/PlayerPrefab.ts
+++ b/src/entities/PlayerPrefab.ts
@@ -15,7 +15,8 @@ import {
   HeadingDirectionComponent,
   IsGameEntityTag,
   ModelComponent,
-  TransformComponent
+  TransformComponent,
+  VelocityComponent
 } from "../components";
 import { ASSETS, KEY_MAPS } from "../constants";
 import {
@@ -44,9 +45,7 @@ export class PlayerBehavior extends Behavior<
     return [new ControlCameraAction(entity, context.time)];
   }
   onUpdate(
-    entity: ActionEntity<
-      typeof TransformComponent | typeof HeadingDirectionComponent
-    >,
+    entity: ReturnType<(typeof PlayerEntity)["create"]>,
     context: BehaviorContext
   ) {
     if (entity.actions.size > 0) {
@@ -101,6 +100,7 @@ export const PlayerEntity: IEntityPrefab<
   EntityWithComponents<
     | typeof BehaviorComponent
     | typeof TransformComponent
+    | typeof VelocityComponent
     | typeof ModelComponent
     | typeof HeadingDirectionComponent
   >
@@ -113,6 +113,8 @@ export const PlayerEntity: IEntityPrefab<
     });
 
     TransformComponent.add(entity);
+
+    VelocityComponent.add(entity);
 
     HeadingDirectionComponent.add(entity);
 

--- a/src/entities/WallEntity.ts
+++ b/src/entities/WallEntity.ts
@@ -1,40 +1,30 @@
 import { EntityWithComponents } from "../Component";
 import { IEntityPrefab } from "../EntityManager";
-import { PushAction } from "../actions";
+import { Message } from "../Message";
 import {
   AddedTag,
   BehaviorComponent,
   IdComponent,
   IsGameEntityTag,
   ModelComponent,
+  TilePositionComponent,
   TransformComponent
 } from "../components";
 import { ASSETS } from "../constants";
-import { BehaviorCacheState, EntityManagerState } from "../state";
-import { Action } from "../systems/ActionSystem";
+import { CanMoveMessage } from "../messages";
+import { BehaviorState, EntityManagerState } from "../state";
 import { Behavior } from "../systems/BehaviorSystem";
 
 export class WallBehavior extends Behavior<any, any> {
   static id = "behavior/wall";
-  onReceive(actions: ReadonlyArray<Action<any, any>>) {
-    const returnedActions: Action<ReturnType<typeof WallEntity.create>, any>[] =
-      [];
-    const pushes = [];
-
-    for (const action of actions) {
-      if (action instanceof PushAction) {
-        pushes.push(action);
-      }
+  onReceive(message: Message<any>) {
+    if (message instanceof CanMoveMessage) {
+      message.answer = false;
     }
-    for (const action of pushes) {
-      action.cancelled = true;
-    }
-
-    return returnedActions;
   }
 }
 
-type Context = EntityManagerState & BehaviorCacheState;
+type Context = EntityManagerState & BehaviorState;
 export const WallEntity: IEntityPrefab<
   Context,
   EntityWithComponents<typeof BehaviorComponent | typeof TransformComponent>
@@ -53,6 +43,8 @@ export const WallEntity: IEntityPrefab<
     });
 
     TransformComponent.add(entity);
+
+    TilePositionComponent.add(entity);
 
     IsGameEntityTag.add(entity);
 

--- a/src/functions/Networking.ts
+++ b/src/functions/Networking.ts
@@ -1,15 +1,5 @@
 import { IComponentDefinition } from "../Component";
-import {
-  AddedTag,
-  AnimationComponent,
-  BehaviorComponent,
-  HeadingDirectionComponent,
-  IsActiveTag,
-  IsGameEntityTag,
-  ModelComponent,
-  ServerIdComponent,
-  TransformComponent
-} from "../components";
+import { NETWORK_COMPONENTS } from "../constants";
 
 function set(entity: any, component: IComponentDefinition<any>, data: any) {
   // check before adding because adding always notifies observers
@@ -36,27 +26,15 @@ function maybeSerialize(
   }
 }
 
-const components = [
-  ServerIdComponent,
-  TransformComponent,
-  AnimationComponent,
-  ModelComponent,
-  BehaviorComponent,
-  HeadingDirectionComponent,
-  IsActiveTag,
-  IsGameEntityTag,
-  AddedTag
-];
-
 export function deserializeEntity(entity: any, data: any) {
-  for (const component of components) {
+  for (const component of NETWORK_COMPONENTS) {
     update(entity, component, data);
   }
   return entity;
 }
 
 export function serializeEntity(entity: any, target = {}) {
-  for (const component of components) {
+  for (const component of NETWORK_COMPONENTS) {
     maybeSerialize(entity, component, target);
   }
   return target;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,61 @@
+import { Vector3 } from "three";
+import {
+  IMessageReceiver,
+  IMessageSender,
+  Message,
+  createMessage,
+  sendMessage
+} from "./Message";
+import { BehaviorState, TilesState } from "./state";
+import { TileEntity } from "./systems/TileSystem";
+import { invariant } from "./Error";
+import { TilePositionComponent } from "./components";
+import { convertToTiles } from "./units/convert";
+
+/** Ask an actor if it can move from its current position to its position plus `delta`. */
+export class CanMoveMessage extends Message<boolean> {
+  answer = true;
+  constructor(
+    receiver: IMessageReceiver,
+    sender: IMessageSender,
+    readonly delta: Vector3
+  ) {
+    super(receiver, sender);
+  }
+
+  static getReceiver(
+    delta: Vector3,
+    senderTilePosition: Vector3,
+    context: TilesState
+  ) {
+    const { x, y } = senderTilePosition;
+    const dx = convertToTiles(delta.x);
+    const dy = convertToTiles(delta.y);
+    return context.tiles.get(x + dx, y + dy) as TileEntity & IMessageReceiver;
+  }
+
+  forward(context: TilesState & BehaviorState) {
+    const nextSender = this.receiver;
+    invariant(
+      TilePositionComponent.has(nextSender),
+      `Expected receiver to have tile position component`
+    );
+    invariant("outbox" in nextSender, "Expected receiver to have an outbox");
+    const { delta } = this;
+    const nextReceiver = CanMoveMessage.getReceiver(
+      delta,
+      nextSender.tilePosition,
+      context
+    );
+    if (nextReceiver) {
+      return (this.answer = sendMessage(
+        createMessage(CanMoveMessage, delta)
+          .from(nextSender as IMessageSender)
+          .to(nextReceiver),
+        context
+      ));
+    }
+  }
+}
+
+export class WinMessage extends Message<void> {}

--- a/src/systems/ActionDebugSystem.ts
+++ b/src/systems/ActionDebugSystem.ts
@@ -6,7 +6,8 @@ import {
   UIElementArrayOptions,
   removeElementByIdSafely
 } from "../UIElement";
-import { Action, ActionEntity } from "./ActionSystem";
+import { ActionEntity } from "./ActionSystem";
+import { Action } from "../Action";
 
 const UIAction = (data: Action<ActionEntity<any>, any>) => {
   return UIBuiltIn.TR({

--- a/src/systems/ActionSystem.test.ts
+++ b/src/systems/ActionSystem.test.ts
@@ -1,10 +1,11 @@
-import test from "node:test";
-import { Action, ActionSystem } from "./ActionSystem";
+import test, { describe } from "node:test";
+import { ActionSystem, UndoState } from "./ActionSystem";
 import { BehaviorComponent, ChangedTag } from "../components";
-import { MockState, getMock } from "../testHelpers";
+import { MockState } from "../testHelpers";
 import assert from "node:assert";
 import { SystemManager } from "../System";
 import { World } from "../EntityManager";
+import { Action } from "../Action";
 
 class MockAction extends Action<any, any> {
   constructor(entity: any, startTime: number, maxElapsedTime: number) {
@@ -14,162 +15,145 @@ class MockAction extends Action<any, any> {
   update = test.mock.fn((_context: any) => {});
 }
 
-test("processing pending actions", () => {
-  const world = new World();
-  const entity = world.addEntity();
-  const state = new MockState();
-  const mgr = new SystemManager(state);
+function almostEqual(a: number, b: number) {
+  return Math.abs(a - b) < 0.001;
+}
 
-  BehaviorComponent.add(entity, { behaviorId: "behavior/mock" });
+describe("ActionSystem", () => {
+  describe("processing pending actions", () => {
+    const world = new World();
+    const entity = world.addEntity();
+    const state = new MockState();
+    const mgr = new SystemManager(state);
 
-  const actions = [
-    new MockAction(entity, 0, 22),
-    new MockAction(entity, 0, 33)
-  ];
-  const system = new ActionSystem(mgr);
+    BehaviorComponent.add(entity, { behaviorId: "behavior/mock" });
 
-  state.pendingActions.push(...actions);
+    // The system currently assumes that all pending actions should be started immediately
+    const actions = [
+      new MockAction(entity, 0, 12),
+      new MockAction(entity, 0, 15),
+      new MockAction(entity, 0, 24)
+    ];
+    const system = new ActionSystem(mgr);
 
-  system.update(state);
-  assert.equal(state.pendingActions.length, 2);
-  assert.equal(state.completedActions.length, 0);
-  assert.equal(getMock(actions[0].seek).callCount(), 1);
-  assert.equal(getMock(actions[1].seek).callCount(), 1);
-  assert.equal(getMock(actions[0].update).callCount(), 1);
-  assert.equal(getMock(actions[1].update).callCount(), 1);
+    system.start(state);
 
-  state.dt = 22;
-  system.update(state);
-  assert.equal(state.pendingActions.length, 1);
-  assert.equal(state.completedActions.length, 1);
-  assert.equal(getMock(actions[0].seek).callCount(), 2);
-  assert.equal(getMock(actions[1].seek).callCount(), 2);
-  assert.equal(getMock(actions[0].update).callCount(), 2);
-  assert.equal(getMock(actions[1].update).callCount(), 2);
+    state.pendingActions.push(...actions);
 
-  state.dt = 33;
-  system.update(state);
-  assert.equal(state.pendingActions.length, 0);
-  assert.equal(state.completedActions.length, 2);
-  assert.equal(getMock(actions[0].seek).callCount(), 2);
-  assert.equal(getMock(actions[1].seek).callCount(), 3);
-  assert.equal(getMock(actions[0].update).callCount(), 2);
-  assert.equal(getMock(actions[1].update).callCount(), 3);
-  assert.equal(entity.actions.size, 0);
-  assert(ChangedTag.has(entity));
-});
+    test("when dt is zero, nothing happens", () => {
+      system.update(state);
+      assert.equal(state.time, 0);
+      assert.equal(actions[0].progress, 0);
+      assert.equal(actions[1].progress, 0);
+      assert.equal(state.pendingActions.length, 3);
+      assert.equal(state.completedActions.length, 0);
+      assert.equal(entity.actions.size, 3);
+    });
 
-test("undoing completed actions", () => {
-  const world = new World();
-  const entity = world.addEntity();
-  const state = new MockState();
-  const mgr = new SystemManager(state);
-  const { undoingActions, completedActions, pendingActions } = state;
+    test("actions are moved to complete as time passes", () => {
+      state.dt = 12;
+      system.update(state);
+      assert.equal(state.time, 12);
+      assert.equal(actions[0].progress, 1);
+      assert.equal(actions[1].progress, 12 / 15);
+      assert.equal(actions[2].progress, 12 / 24);
+      assert.equal(state.pendingActions.length, 2);
+      assert.equal(state.completedActions.length, 1);
+      assert.equal(entity.actions.size, 2);
+      assert(ChangedTag.has(entity));
+    });
 
-  BehaviorComponent.add(entity, { behaviorId: "behavior/mock" });
+    test("finishing up", () => {
+      state.dt = 12;
+      system.update(state);
+      assert.equal(state.time, 24);
+      assert.equal(actions[0].progress, 1);
+      assert.equal(actions[1].progress, 1);
+      assert.equal(actions[2].progress, 1);
+      assert.equal(state.pendingActions.length, 0);
+      assert.equal(state.completedActions.length, 3);
+      assert.equal(entity.actions.size, 0);
+      assert(ChangedTag.has(entity));
+    });
+  });
 
-  const system = new ActionSystem(mgr);
+  describe("undoing completed actions", () => {
+    const world = new World();
+    const entity = world.addEntity();
+    const state = new MockState();
+    const mgr = new SystemManager(state);
+    const { undoingActions, completedActions, pendingActions } = state;
 
-  state.time = 38;
-  state.undoUntilTime = 0;
-  state.undoRequested = true;
+    BehaviorComponent.add(entity, { behaviorId: "behavior/mock" });
 
-  // add some completed actions
-  const actions = [
-    new MockAction(entity, 6, 12),
-    new MockAction(entity, 12, 12),
-    new MockAction(entity, 18, 12)
-  ];
-  pendingActions.push(...actions);
+    const system = new ActionSystem(mgr);
 
-  // Give it enough time to process the pending actions and switch to undoing
-  state.dt = 30;
-  system.update(state);
+    state.time = 42;
+    Action.nextId = 0;
+    state.undoActionId = 2;
 
-  for (const action of actions) {
-    getMock(action.update).resetCalls();
-  }
+    // add some completed actions
+    const actions = [
+      new MockAction(entity, 6, 12),
+      new MockAction(entity, 12, 12),
+      new MockAction(entity, 12, 15),
+      new MockAction(entity, 18, 12)
+    ];
 
-  // Always starts undoing at least 1 action, skipping over empty time segments
-  state.dt = 4;
-  system.update(state);
-  assert.equal(pendingActions.length, 0);
-  assert.equal(undoingActions.length, 1);
-  assert.equal(completedActions.length, 2);
-  assert.equal(getMock(actions[2].update).callCount(), 1);
-  assert.equal(getMock(actions[1].update).callCount(), 0);
-  assert.equal(getMock(actions[0].update).callCount(), 0);
-  assert.equal(entity.actions.size, 1);
-  assert.equal(state.time, 28);
+    system.start(state);
 
-  // Can undo multiple actions at once
-  state.dt = 6;
-  system.update(state);
-  assert.equal(pendingActions.length, 0);
-  assert.equal(undoingActions.length, 2);
-  assert.equal(completedActions.length, 1);
-  assert.equal(getMock(actions[2].update).callCount(), 2);
-  assert.equal(getMock(actions[1].update).callCount(), 1);
-  assert.equal(getMock(actions[0].update).callCount(), 0);
-  assert.equal(entity.actions.size, 2);
-  assert.equal(state.time, 22);
+    test("doesn't crash if there aren't any pending actions", () => {
+      state.undoState = UndoState.FinishPendingActions;
+      state.dt = 0;
+      system.update(state);
+      assert.equal(state.time, 42);
+    });
 
-  // Finishing
-  state.dt = 22;
-  system.update(state);
-  assert.equal(pendingActions.length, 0);
-  assert.equal(undoingActions.length, 0);
-  assert.equal(completedActions.length, 0);
-  assert.equal(getMock(actions[2].update).callCount(), 3);
-  assert.equal(getMock(actions[1].update).callCount(), 2);
-  assert.equal(getMock(actions[0].update).callCount(), 1);
-  assert.equal(entity.actions.size, 0);
-  assert.equal(state.time, 0);
-  assert(!state.undoInProgress);
-  assert(!state.undoRequested);
-});
+    test("finishes up pending actions before beginning to undo", () => {
+      pendingActions.push(...actions);
+      state.undoState = UndoState.FinishPendingActions;
+      state.dt = 30;
+      system.update(state);
+      assert.equal(state.time, 72);
+      assert.equal(actions[0].progress, 1);
+      assert.equal(actions[1].progress, 1);
+      assert.equal(actions[2].progress, 1);
+      assert.equal(actions[3].progress, 1);
+      assert.equal(pendingActions.length, 0);
+      assert.equal(undoingActions.length, 4);
+      assert.equal(completedActions.length, 0);
+      assert.equal(state.undoState, UndoState.Undoing);
+    });
 
-test("handling directly and indirectly cancelled actions", () => {
-  const world = new World();
-  const player = world.addEntity();
-  const block1 = world.addEntity();
-  const block2 = world.addEntity();
-  const state = new MockState();
-  const mgr = new SystemManager(state);
-  const { pendingActions, completedActions } = state;
+    test("when beginning to undo, the appropriate actions are moved from complete to undoing", () => {
+      assert.equal(state.pendingActions.length, 0);
+      assert.equal(state.completedActions.length, 0);
+      assert.equal(state.undoingActions.length, 4);
+    });
 
-  BehaviorComponent.add(player, { behaviorId: "behavior/mock" });
-  BehaviorComponent.add(block1, { behaviorId: "behavior/mock" });
-  BehaviorComponent.add(block2, { behaviorId: "behavior/mock" });
+    test("uses dt to step back through the actions (multiple actions can start at once)", () => {
+      state.dt = 46;
+      system.update(state);
+      console.log("time", state.time);
+      assert.equal(actions[0].progress, 1);
+      assert.equal(actions[1].progress, 1);
+      assert(almostEqual(actions[2].progress, 14 / 15));
+      assert(almostEqual(actions[3].progress, 8 / 12));
+      assert.equal(pendingActions.length, 0);
+      assert.equal(undoingActions.length, 4);
+      assert.equal(completedActions.length, 0);
+    });
 
-  const actions = [
-    new MockAction(player, 0, 1),
-    new MockAction(block1, 0, 1),
-    new MockAction(block2, 0, 1)
-  ];
-  const system = new ActionSystem(mgr);
-
-  pendingActions.push(...actions);
-
-  pendingActions.at(1)!.causes.add(pendingActions.at(0)!);
-  pendingActions.at(2)!.causes.add(pendingActions.at(1)!);
-  pendingActions.at(2)!.cancelled = true;
-
-  assert.equal(player.actions.size, 1);
-  assert.equal(block1.actions.size, 1);
-  assert.equal(block2.actions.size, 1);
-  system.update(state);
-  assert.equal(pendingActions.length, 0);
-  assert.equal(completedActions.length, 0);
-  assert.equal(getMock(actions[0].update).callCount(), 0);
-  assert.equal(getMock(actions[1].update).callCount(), 0);
-  assert.equal(getMock(actions[2].update).callCount(), 0);
-  assert.equal(player.actions.size, 0);
-  assert.equal(block1.actions.size, 0);
-  assert.equal(block2.actions.size, 0);
-  assert(player.cancelledActions.has(actions[0]));
-  assert(block1.cancelledActions.has(actions[1]));
-  assert(block2.cancelledActions.has(actions[2]));
-  assert(actions[0].cancelled);
-  assert(actions[1].cancelled);
+    test("finishing", () => {
+      state.dt = 26;
+      system.update(state);
+      assert.equal(actions[0].progress, 0);
+      assert.equal(actions[1].progress, 0);
+      assert.equal(actions[2].progress, 0);
+      assert.equal(actions[3].progress, 0);
+      assert.equal(pendingActions.length, 0);
+      assert.equal(undoingActions.length, 0);
+      assert.equal(completedActions.length, 0);
+    });
+  });
 });

--- a/src/systems/EditorSystem.ts
+++ b/src/systems/EditorSystem.ts
@@ -31,12 +31,14 @@ export class EditorSystem extends SystemWithQueries<State> {
     );
   }
   update(context: State): void {
+    // TODO this should be handled by a higher-level system
     switch (context.metaStatus) {
       case MetaStatus.Restart:
         {
-          context.resetWorld(this.#gameNtts);
+          context.clearWorld();
           this.mgr.clear();
           this.mgr.push(createRouterSystem(ROUTES, context.currentRoute));
+          context.addAllEntities(context.originalWorld);
         }
         break;
     }

--- a/src/systems/GameSystem.ts
+++ b/src/systems/GameSystem.ts
@@ -29,12 +29,15 @@ export class GameSystem extends SystemWithQueries<QueryState> {
     context.metaStatus = MetaStatus.Play;
   }
   async update(context: Context) {
+    // TODO this should be handled by a higher-level system
     switch (context.metaStatus) {
       case MetaStatus.Restart:
         {
-          context.resetWorld(this.#gameEntities);
+          // TODO this is slow
+          context.clearWorld();
           this.mgr.clear();
           this.mgr.push(createRouterSystem(ROUTES, context.currentRoute));
+          context.addAllEntities(context.originalWorld);
         }
         break;
       case MetaStatus.Win:

--- a/src/systems/RouterSystem.ts
+++ b/src/systems/RouterSystem.ts
@@ -1,9 +1,9 @@
 import { ISystemConstructor, System } from "../System";
 import { GlobalInputEntity } from "../entities/GlobalInputEntity";
 import { URLSearchParams, location } from "../globals";
-import { BehaviorCacheState, EntityManagerState, RouterState } from "../state";
+import { BehaviorState, EntityManagerState, RouterState } from "../state";
 
-type Context = RouterState & EntityManagerState & BehaviorCacheState;
+type Context = RouterState & EntityManagerState & BehaviorState;
 
 export type IRouteRecord = Record<string, Set<ISystemConstructor<any>>>;
 

--- a/src/systems/TileSystem.ts
+++ b/src/systems/TileSystem.ts
@@ -4,11 +4,13 @@ import {
   AddedTag,
   ChangedTag,
   IsGameEntityTag,
-  TransformComponent
+  TransformComponent,
+  VelocityComponent
 } from "../components";
 import { convertToTilesMax, convertToTilesMin } from "../units/convert";
-import { ActionsState, QueryState, TilesState } from "../state";
+import { ActionsState, QueryState, TilesState, TimeState } from "../state";
 import { EntityWithComponents } from "../Component";
+import { Vector2 } from "three";
 
 function placeEntityOnTile(
   tiles: TilesState["tiles"],
@@ -21,32 +23,61 @@ function placeEntityOnTile(
   tiles.set(tileX, tileY, set);
 }
 
+const _tileCoords = new Vector2();
+function* getWholeNumberPointsInRectangle(
+  xMin: number,
+  yMin: number,
+  xMax: number,
+  yMax: number
+) {
+  for (let x = xMin; x <= xMax; x++) {
+    for (let y = yMin; y <= yMax; y++) {
+      _tileCoords.set(x, y);
+      yield _tileCoords;
+    }
+  }
+}
+
 function placeEntityOnTiles(
   tiles: TilesState["tiles"],
-  entity: EntityWithComponents<typeof TransformComponent>
+  entity: EntityWithComponents<typeof TransformComponent>,
+  deltaTime: number
 ) {
-  const { position } = entity.transform;
-  const tileXMax = convertToTilesMax(position.x);
-  const tileXMin = convertToTilesMin(position.x);
-  const tileYMax = convertToTilesMax(position.y);
-  const tileYMin = convertToTilesMin(position.y);
-  placeEntityOnTile(tiles, entity, tileXMin, tileYMin);
-  placeEntityOnTile(tiles, entity, tileXMax, tileYMin);
-  placeEntityOnTile(tiles, entity, tileXMin, tileYMax);
-  placeEntityOnTile(tiles, entity, tileXMax, tileYMax);
+  const { transform } = entity;
+  const { x, y } = transform.position;
+  let dx2 = 0,
+    dy2 = 0;
+  if (VelocityComponent.has(entity)) {
+    const { velocity } = entity;
+    (dx2 = velocity.x * deltaTime), (dy2 = velocity.y * deltaTime);
+  }
+  const tileXMax = convertToTilesMax(x + dx2);
+  const tileXMin = convertToTilesMin(x);
+  const tileYMax = convertToTilesMax(y + dy2);
+  const tileYMin = convertToTilesMin(y);
+
+  for (const tile of getWholeNumberPointsInRectangle(
+    tileXMin,
+    tileYMin,
+    tileXMax,
+    tileYMax
+  )) {
+    placeEntityOnTile(tiles, entity, tile.x, tile.y);
+  }
 }
 
 function updateTiles(
   tiles: TilesState["tiles"],
-  query: IQueryResults<[typeof TransformComponent]>
+  query: IQueryResults<[typeof TransformComponent]>,
+  deltaTime: number
 ) {
   tiles.clear();
   for (const entity of query) {
-    placeEntityOnTiles(tiles, entity);
+    placeEntityOnTiles(tiles, entity, deltaTime);
   }
 }
 
-type Context = TilesState & QueryState & ActionsState;
+type Context = TilesState & QueryState & ActionsState & TimeState;
 
 export class TileSystem extends SystemWithQueries<Context> {
   #tileQuery = this.createQuery([
@@ -55,18 +86,22 @@ export class TileSystem extends SystemWithQueries<Context> {
     IsGameEntityTag
   ]);
   // TODO(perf): this query should be more specific?
-  #changedQuery = this.createQuery([ChangedTag]);
+  #changedQuery = this.createQuery([
+    ChangedTag,
+    TransformComponent,
+    VelocityComponent
+  ]);
   start(state: Context): void {
-    updateTiles(state.tiles, this.#tileQuery);
+    updateTiles(state.tiles, this.#tileQuery, state.dt);
     this.resources.push(
       this.#changedQuery.onAdd(() => {
-        updateTiles(state.tiles, this.#tileQuery);
+        updateTiles(state.tiles, this.#tileQuery, state.dt);
       }),
       this.#tileQuery.onAdd((entity) =>
-        placeEntityOnTiles(state.tiles, entity)
+        placeEntityOnTiles(state.tiles, entity, state.dt)
       ),
       this.#tileQuery.onRemove(() => {
-        updateTiles(state.tiles, this.#tileQuery);
+        updateTiles(state.tiles, this.#tileQuery, state.dt);
       })
     );
   }

--- a/src/systems/TileSystem.ts
+++ b/src/systems/TileSystem.ts
@@ -4,83 +4,52 @@ import {
   AddedTag,
   ChangedTag,
   IsGameEntityTag,
-  TransformComponent,
-  VelocityComponent
+  TilePositionComponent,
+  TransformComponent
 } from "../components";
-import { convertToTilesMax, convertToTilesMin } from "../units/convert";
+import { convertToTiles } from "../units/convert";
 import { ActionsState, QueryState, TilesState, TimeState } from "../state";
 import { EntityWithComponents } from "../Component";
-import { Vector2 } from "three";
 
-function placeEntityOnTile(
-  tiles: TilesState["tiles"],
-  entity: EntityWithComponents<typeof TransformComponent>,
-  tileX: number,
-  tileY: number
-) {
-  const set = tiles.get(tileX, tileY) || [];
-  set.push(entity);
-  tiles.set(tileX, tileY, set);
-}
+type TileEntityComponents =
+  | typeof TilePositionComponent
+  | typeof TransformComponent;
+export type TileEntity = EntityWithComponents<TileEntityComponents>;
 
-const _tileCoords = new Vector2();
-function* getWholeNumberPointsInRectangle(
-  xMin: number,
-  yMin: number,
-  xMax: number,
-  yMax: number
-) {
-  for (let x = xMin; x <= xMax; x++) {
-    for (let y = yMin; y <= yMax; y++) {
-      _tileCoords.set(x, y);
-      yield _tileCoords;
-    }
-  }
-}
-
-function placeEntityOnTiles(
-  tiles: TilesState["tiles"],
-  entity: EntityWithComponents<typeof TransformComponent>,
-  deltaTime: number
-) {
-  const { transform } = entity;
+function moveEntityToTile(tiles: TilesState["tiles"], entity: TileEntity) {
+  const { tilePosition, transform } = entity;
+  const tileXOld = tilePosition.x;
+  const tileYOld = tilePosition.y;
   const { x, y } = transform.position;
-  let dx2 = 0,
-    dy2 = 0;
-  if (VelocityComponent.has(entity)) {
-    const { velocity } = entity;
-    (dx2 = velocity.x * deltaTime), (dy2 = velocity.y * deltaTime);
+  const tileX = convertToTiles(x);
+  const tileY = convertToTiles(y);
+  if (tiles.get(tileXOld, tileYOld) === entity) {
+    tiles.delete(tileXOld, tileYOld);
   }
-  const tileXMax = convertToTilesMax(x + dx2);
-  const tileXMin = convertToTilesMin(x);
-  const tileYMax = convertToTilesMax(y + dy2);
-  const tileYMin = convertToTilesMin(y);
-
-  for (const tile of getWholeNumberPointsInRectangle(
-    tileXMin,
-    tileYMin,
-    tileXMax,
-    tileYMax
-  )) {
-    placeEntityOnTile(tiles, entity, tile.x, tile.y);
-  }
+  tiles.set(tileX, tileY, entity);
+  entity.tilePosition.set(tileX, tileY, 0);
+  // console.log(
+  //   "tile position for",
+  //   entity.behaviorId,
+  //   entity.tilePosition.toArray()
+  // );
 }
 
 function updateTiles(
   tiles: TilesState["tiles"],
-  query: IQueryResults<[typeof TransformComponent]>,
-  deltaTime: number
+  query: IQueryResults<[TileEntityComponents]>
 ) {
-  tiles.clear();
   for (const entity of query) {
-    placeEntityOnTiles(tiles, entity, deltaTime);
+    moveEntityToTile(tiles, entity);
   }
 }
 
 type Context = TilesState & QueryState & ActionsState & TimeState;
 
+// TODO unit test this
 export class TileSystem extends SystemWithQueries<Context> {
   #tileQuery = this.createQuery([
+    TilePositionComponent,
     TransformComponent,
     AddedTag,
     IsGameEntityTag
@@ -89,19 +58,17 @@ export class TileSystem extends SystemWithQueries<Context> {
   #changedQuery = this.createQuery([
     ChangedTag,
     TransformComponent,
-    VelocityComponent
+    TilePositionComponent
   ]);
   start(state: Context): void {
-    updateTiles(state.tiles, this.#tileQuery, state.dt);
+    updateTiles(state.tiles, this.#tileQuery);
     this.resources.push(
       this.#changedQuery.onAdd(() => {
-        updateTiles(state.tiles, this.#tileQuery, state.dt);
+        updateTiles(state.tiles, this.#changedQuery);
       }),
-      this.#tileQuery.onAdd((entity) =>
-        placeEntityOnTiles(state.tiles, entity, state.dt)
-      ),
+      this.#tileQuery.onAdd((entity) => moveEntityToTile(state.tiles, entity)),
       this.#tileQuery.onRemove(() => {
-        updateTiles(state.tiles, this.#tileQuery, state.dt);
+        updateTiles(state.tiles, this.#tileQuery);
       })
     );
   }


### PR DESCRIPTION
Previously used actions for both inter-entity communication and performing actions. Now entities only queue their own actions and use messages with answers to decide what actions to take.

This required a complete rewrite of the ActionSystem, which is a lot more robust now.