### PR TITLE
Fix tile system coincidence

### DIFF
--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -88,6 +88,13 @@ export class MatrixOfSets<T> extends Matrix<Set<T>, Set<T>> {
     }
     return this;
   }
+  subtract(x: number, y: number, z: number, value: T) {
+    if (super.has(x, y, z)) {
+      const set = super.get(x, y, z)!;
+      return set.delete(value);
+    }
+    return false;
+  }
   get(x: number, y: number, z: number) {
     const value = super.get(x, y, z);
     return value ?? this.#emptySet;

--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -75,7 +75,7 @@ export class Matrix<T, Default = undefined> {
   }
 }
 
-export class MatrixOfSets<T> extends Matrix<Set<T>, Set<T>> {
+export class MatrixOfIterables<T> extends Matrix<Set<T>, Iterable<T>> {
   #emptySet = new SecretlyWritableSet<T>();
   add(x: number, y: number, z: number, value: T) {
     if (super.has(x, y, z)) {
@@ -90,12 +90,15 @@ export class MatrixOfSets<T> extends Matrix<Set<T>, Set<T>> {
   }
   subtract(x: number, y: number, z: number, value: T) {
     if (super.has(x, y, z)) {
-      const set = super.get(x, y, z)!;
+      const set = super.get(x, y, z)! as Set<T>;
       return set.delete(value);
     }
     return false;
   }
-  get(x: number, y: number, z: number) {
+  hasItem(x: number, y: number, z: number, item: T) {
+    return (this.get(x, y, z) as Set<T>).has(item);
+  }
+  get(x: number, y: number, z: number): Iterable<T> {
     const value = super.get(x, y, z);
     return value ?? this.#emptySet;
   }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -111,15 +111,20 @@ export function getMessageWithAnswer<PMessage extends Message<any>>(
   }
 }
 
-export function getReceiver(
+export function getReceivers(
   tiles: TileMatrix,
   vecInTiles: Vector3
-): EntityWithComponents<typeof BehaviorComponent> | undefined {
-  const receiver = tiles.atPoint(vecInTiles);
-  if (receiver) {
-    const hasBehavior = BehaviorComponent.has(receiver);
-    if (hasBehavior) {
-      return receiver;
-    }
+): Iterable<EntityWithComponents<typeof BehaviorComponent>> {
+  const receivers = tiles.atPoint(vecInTiles);
+
+  let allHaveBehavior = true;
+  for (const entity of receivers) {
+    allHaveBehavior &&= BehaviorComponent.has(entity);
   }
+  invariant(
+    allHaveBehavior,
+    "Expected tile entities to have behavior components"
+  );
+
+  return receivers as Iterable<EntityWithComponents<typeof BehaviorComponent>>;
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -166,23 +166,27 @@ export class CreateEntityAction<
   }
 }
 
-export class RemoveEntityAction<
+export class RemoveEntitiesAction<
   Entity extends ActionEntity<typeof TransformComponent>
 > extends Action<Entity, {}> {
   constructor(
     entity: Entity,
     startTime: number,
-    readonly entityToRemove: EntityWithComponents<any>
+    readonly entities: Iterable<EntityWithComponents<any>>
   ) {
     super(entity, startTime, 0);
   }
   update() {
-    const { entityToRemove } = this;
+    const { entities } = this;
     if (this.progress > 0) {
-      AddedTag.remove(entityToRemove);
-      ChangedTag.add(entityToRemove);
+      for (const ntt of entities) {
+        AddedTag.remove(ntt);
+        ChangedTag.add(ntt);
+      }
     } else {
-      AddedTag.add(entityToRemove);
+      for (const ntt of entities) {
+        AddedTag.add(ntt);
+      }
     }
   }
 }

--- a/src/collections/SecretlyWritableSet.ts
+++ b/src/collections/SecretlyWritableSet.ts
@@ -1,0 +1,9 @@
+export class SecretlyWritableSet<T> extends Set<T> {
+  add(value: T): this {
+    void value;
+    throw "Cannot add to a readonly set";
+  }
+  _add(value: T): this {
+    return super.add(value);
+  }
+}

--- a/src/entities/BlockEntity.ts
+++ b/src/entities/BlockEntity.ts
@@ -14,7 +14,7 @@ import { ASSETS } from "../constants";
 import { BehaviorState, EntityManagerState, TimeState } from "../state";
 import { Behavior, hasSameBehavior } from "../systems/BehaviorSystem";
 import { CanMoveMessage } from "../messages";
-import { Message, createMessage, getReceiver, sendMessage } from "../Message";
+import { Message, createMessage, getReceivers, sendMessage } from "../Message";
 import { ITilesState } from "../systems/TileSystem";
 
 type Entity = ReturnType<typeof BlockEntity.create>;
@@ -31,9 +31,9 @@ export class BlockBehavior extends Behavior<any, any> {
     // Send CanMoveMessage down to press buttons
     vecInTiles.copy(tilePosition);
     vecInTiles.z -= 1;
-    const receiver = getReceiver(context.tiles, vecInTiles);
+    const receivers = getReceivers(context.tiles, vecInTiles);
 
-    if (receiver) {
+    for (const receiver of receivers) {
       sendMessage(
         createMessage(CanMoveMessage, vecInTiles).from(entity).to(receiver),
         context

--- a/src/entities/CursorEntity.ts
+++ b/src/entities/CursorEntity.ts
@@ -23,7 +23,7 @@ import {
   ControlCameraAction,
   CreateEntityAction,
   MoveAction,
-  RemoveEntityAction,
+  RemoveEntitiesAction,
   SetAnimationClipAction
 } from "../actions";
 import { invariant } from "../Error";
@@ -76,10 +76,10 @@ export class CursorBehavior extends Behavior<Entity, Context> {
               // log.append(
               //   `Deleting entity ${nttUnderCursor} from (${tileX}, ${tileY}, ${tileZ})`
               // );
-              return [new RemoveEntityAction(entity, time, nttAtCursor)];
+              return [new RemoveEntitiesAction(entity, time, nttAtCursor)];
             }
             if (nttBelowCursor !== undefined) {
-              return [new RemoveEntityAction(entity, time, nttBelowCursor)];
+              return [new RemoveEntitiesAction(entity, time, nttBelowCursor)];
             }
             break;
           }
@@ -110,7 +110,7 @@ export class CursorBehavior extends Behavior<Entity, Context> {
               return [
                 new SetAnimationClipAction(entity, time, "normal"),
                 ...(nttUnderCursor !== undefined
-                  ? [new RemoveEntityAction(entity, time, nttUnderCursor)]
+                  ? [new RemoveEntitiesAction(entity, time, nttUnderCursor)]
                   : []),
                 new CreateEntityAction(
                   entity,

--- a/src/entities/MonsterEntity.ts
+++ b/src/entities/MonsterEntity.ts
@@ -2,7 +2,7 @@ import { Vector3 } from "three";
 import { EntityWithComponents } from "../Component";
 import { IEntityPrefab } from "../EntityManager";
 import { HeadingDirection } from "../HeadingDirection";
-import { Message, createMessage, getReceiver, sendMessage } from "../Message";
+import { Message, createMessage, getReceivers, sendMessage } from "../Message";
 import { MoveAction, RotateAction } from "../actions";
 import {
   AddedTag,
@@ -60,16 +60,15 @@ export class MonsterBehavior extends Behavior<
       convertPropertiesToTiles(vecInTiles);
       vecInTiles.add(entity.tilePosition);
 
-      const receiver = getReceiver(context.tiles, vecInTiles);
+      const receivers = getReceivers(context.tiles, vecInTiles);
 
-      canMove = receiver
-        ? sendMessage(
-            createMessage(CanMoveMessage, vecInPixels)
-              .from(entity)
-              .to(receiver),
-            context
-          )
-        : true;
+      canMove = true;
+      for (const receiver of receivers) {
+        canMove &&= sendMessage(
+          createMessage(CanMoveMessage, vecInPixels).from(entity).to(receiver),
+          context
+        );
+      }
       // console.log(
       //   "sent message to",
       //   HeadingDirectionValue[headingDirection],

--- a/src/entities/PlayerPrefab.ts
+++ b/src/entities/PlayerPrefab.ts
@@ -5,7 +5,7 @@ import { Key } from "../Input";
 import {
   Message,
   createMessage,
-  getReceiver,
+  getReceivers,
   hasAnswer,
   sendMessage
 } from "../Message";
@@ -68,9 +68,9 @@ export class PlayerBehavior extends Behavior<Entity, BehaviorContext> {
     // Send CanMoveMessage down to press buttons
     vecInTiles.copy(tilePosition);
     vecInTiles.z -= 1;
-    const receiver = getReceiver(context.tiles, vecInTiles);
+    const receivers = getReceivers(context.tiles, vecInTiles);
 
-    if (receiver) {
+    for (const receiver of receivers) {
       sendMessage(
         createMessage(CanMoveMessage, vecInPixels).from(entity).to(receiver),
         context
@@ -83,9 +83,9 @@ export class PlayerBehavior extends Behavior<Entity, BehaviorContext> {
       vecInTiles.copy(vecInPixels);
       convertPropertiesToTiles(vecInTiles);
       vecInTiles.add(tilePosition);
-      const receiver = getReceiver(context.tiles, vecInTiles);
+      const receivers = getReceivers(context.tiles, vecInTiles);
 
-      if (receiver) {
+      for (const receiver of receivers) {
         sendMessage(
           createMessage(CanMoveMessage, vecInPixels).from(entity).to(receiver),
           context
@@ -105,7 +105,7 @@ export class PlayerBehavior extends Behavior<Entity, BehaviorContext> {
       const direction = KEY_MAPS.MOVE[inputPressed as Key];
 
       const canMoveMessages = entity.outbox.getAll(CanMoveMessage);
-      if (canMoveMessages.size === 0 || hasAnswer(canMoveMessages, true)) {
+      if (canMoveMessages.size === 0 || !hasAnswer(canMoveMessages, false)) {
         const moveAction = new MoveAction(entity, context.time, vecInPixels);
         actions.push(moveAction);
       }

--- a/src/entities/PlayerPrefab.ts
+++ b/src/entities/PlayerPrefab.ts
@@ -104,6 +104,7 @@ export class PlayerBehavior extends Behavior<Entity, BehaviorContext> {
     if (inputPressed in KEY_MAPS.MOVE) {
       const direction = KEY_MAPS.MOVE[inputPressed as Key];
 
+      // TODO encapsulate shared logic b/t monster and player
       const canMoveMessages = entity.outbox.getAll(CanMoveMessage);
       if (canMoveMessages.size === 0 || !hasAnswer(canMoveMessages, false)) {
         const moveAction = new MoveAction(entity, context.time, vecInPixels);

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -4,7 +4,7 @@ import {
   IMessageSender,
   Message,
   createMessage,
-  getReceiver,
+  getReceivers,
   sendMessage
 } from "./Message";
 import { BehaviorState } from "./state";
@@ -37,10 +37,10 @@ export class CanMoveMessage extends Message<boolean> {
     vecInTiles.copy(delta);
     convertPropertiesToTiles(vecInTiles);
     vecInTiles.add(nextSender.tilePosition);
-    const nextReceiver = getReceiver(context.tiles, vecInTiles);
+    const nextReceivers = getReceivers(context.tiles, vecInTiles);
 
-    if (nextReceiver) {
-      return (this.answer = sendMessage(
+    for (const nextReceiver of nextReceivers) {
+      return (this.answer &&= sendMessage(
         createMessage(CanMoveMessage, delta)
           .from(nextSender as IMessageSender)
           .to(nextReceiver),

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -11,7 +11,7 @@ import { Observable, ObservableArray } from "../Observable";
 import { Behavior } from "../systems/BehaviorSystem";
 import { CursorEntity } from "../entities/CursorEntity";
 import { KeyCombo } from "../Input";
-import { MatrixOfSets } from "../Matrix";
+import { MatrixOfIterables } from "../Matrix";
 import { invariant } from "../Error";
 import { MixinType, composeMixins, hasMixin } from "../Mixins";
 import { EntityWithComponents } from "../Component";
@@ -250,7 +250,7 @@ export type ActionsState = MixinType<typeof ActionsMixin>;
 
 export function TilesMixin<TBase extends IConstructor>(Base: TBase) {
   return class extends Base implements ITilesState {
-    tiles = new MatrixOfSets<TileEntity>();
+    tiles = new MatrixOfIterables<TileEntity>();
   };
 }
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -11,7 +11,7 @@ import { Observable, ObservableArray } from "../Observable";
 import { Behavior } from "../systems/BehaviorSystem";
 import { CursorEntity } from "../entities/CursorEntity";
 import { KeyCombo } from "../Input";
-import { Matrix } from "../Matrix";
+import { MatrixOfSets } from "../Matrix";
 import { invariant } from "../Error";
 import { MixinType, composeMixins, hasMixin } from "../Mixins";
 import { EntityWithComponents } from "../Component";
@@ -250,7 +250,7 @@ export type ActionsState = MixinType<typeof ActionsMixin>;
 
 export function TilesMixin<TBase extends IConstructor>(Base: TBase) {
   return class extends Base implements ITilesState {
-    tiles = new Matrix<TileEntity>();
+    tiles = new MatrixOfSets<TileEntity>();
   };
 }
 

--- a/src/systems/TileSystem.ts
+++ b/src/systems/TileSystem.ts
@@ -10,7 +10,7 @@ import {
 import { convertToTiles } from "../units/convert";
 import { ActionsState, QueryState, TimeState } from "../state";
 import { EntityWithComponents } from "../Component";
-import { Matrix } from "../Matrix";
+import { MatrixOfSets } from "../Matrix";
 
 type TileEntityComponents =
   | typeof TilePositionComponent
@@ -19,7 +19,7 @@ export type TileEntity = EntityWithComponents<TileEntityComponents>;
 
 type Context = ITilesState & QueryState & ActionsState & TimeState;
 
-export type TileMatrix = Matrix<TileEntity>;
+export type TileMatrix = MatrixOfSets<TileEntity>;
 
 export interface ITilesState {
   tiles: TileMatrix;
@@ -60,7 +60,7 @@ export class TileSystem extends SystemWithQueries<Context> {
   }
   moveEntityToTile(tiles: TileMatrix, entity: TileEntity) {
     const { x, y, z } = entity.tilePosition;
-    if (tiles.get(x, y, z) === entity) {
+    if (tiles.get(x, y, z).has(entity)) {
       this.removeEntityFromTile(tiles, entity);
     }
     this.placeEntityOnTile(tiles, entity);
@@ -73,7 +73,7 @@ export class TileSystem extends SystemWithQueries<Context> {
     const tileX = convertToTiles(x);
     const tileY = convertToTiles(y);
     const tileZ = convertToTiles(z);
-    tiles.set(tileX, tileY, tileZ, entity);
+    tiles.add(tileX, tileY, tileZ, entity);
     entity.tilePosition.set(tileX, tileY, tileZ);
   }
   removeEntityFromTile(tiles: TileMatrix, entity: TileEntity) {

--- a/src/systems/TileSystem.ts
+++ b/src/systems/TileSystem.ts
@@ -10,7 +10,7 @@ import {
 import { convertToTiles } from "../units/convert";
 import { ActionsState, QueryState, TimeState } from "../state";
 import { EntityWithComponents } from "../Component";
-import { MatrixOfSets } from "../Matrix";
+import { MatrixOfIterables } from "../Matrix";
 
 type TileEntityComponents =
   | typeof TilePositionComponent
@@ -19,7 +19,7 @@ export type TileEntity = EntityWithComponents<TileEntityComponents>;
 
 type Context = ITilesState & QueryState & ActionsState & TimeState;
 
-export type TileMatrix = MatrixOfSets<TileEntity>;
+export type TileMatrix = MatrixOfIterables<TileEntity>;
 
 export interface ITilesState {
   tiles: TileMatrix;
@@ -60,7 +60,7 @@ export class TileSystem extends SystemWithQueries<Context> {
   }
   moveEntityToTile(tiles: TileMatrix, entity: TileEntity) {
     const { x, y, z } = entity.tilePosition;
-    if (tiles.get(x, y, z).has(entity)) {
+    if (tiles.hasItem(x, y, z, entity)) {
       this.removeEntityFromTile(tiles, entity);
     }
     this.placeEntityOnTile(tiles, entity);

--- a/src/systems/TileSystem.ts
+++ b/src/systems/TileSystem.ts
@@ -78,7 +78,7 @@ export class TileSystem extends SystemWithQueries<Context> {
   }
   removeEntityFromTile(tiles: TileMatrix, entity: TileEntity) {
     const { x, y, z } = entity.tilePosition;
-    tiles.delete(x, y, z);
+    tiles.subtract(x, y, z, entity);
     // this.log(`removed entity from ${stringifyTileCoords(x, y, z)}`);
   }
   updateTiles(tiles: TileMatrix, query: IQueryResults<[TileEntityComponents]>) {


### PR DESCRIPTION
Before, the state only kept track of the last entity to be placed in a tile, but multiple entities can be in the same tile at once. So when that happened, then one of those entities moved, the state would say that tile is empty when it isn't.

After, the state keeps track of the set of entities within a tile. When an entity moved into a tile, it is added to that set. When it moves out, it is removed.

The fact that it's a set is hidden from consumers of the state's tiles API. All they see is an Iterable of entities.